### PR TITLE
Allow reporting other types of coverage than branches

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ inputs:
   coverage-file:
     description: summary coverage json file (glob)
     required: true
+  coverage-mode:
+    description: which type of coverage is reported (branches, functions, statements, lines)
+    default: 'branches'
+    required: false
   github-token:
     description: github token for octokit
     required: true


### PR DESCRIPTION
While branches might be the appropriate, we often talk about lines (even if that has obvious downsides). Allow reporting out functions, statements and lines in addition to branches.